### PR TITLE
add wheel to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     url='https://github.com/trifonovmixail/pytest-allure-dsl',
     py_modules=['pytest_allure_dsl'],
     install_requires=[
+        'wheel',
         'pytest',
         'pytest-allure-adaptor2>=1.7.11',
         'PyYAML',


### PR DESCRIPTION
Got this issue on Macbook Pro 2019, Catalina 10.15.4, Python 3.8.2 (from brew):
WARNING: The wheel package is not available.
...
error: invalid command 'bdist_wheel'